### PR TITLE
Feature bodies panel overhaul

### DIFF
--- a/OrbitLearn/Assets/Prefabs/UI/ButtonCosmetic.prefab
+++ b/OrbitLearn/Assets/Prefabs/UI/ButtonCosmetic.prefab
@@ -32,10 +32,10 @@ RectTransform:
   m_Father: {fileID: 3034463235826570595}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.3311112}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 21, y: 7}
-  m_SizeDelta: {x: 200, y: 12}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 21, y: -11.5}
+  m_SizeDelta: {x: -100, y: -175}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2377216038711453175
 CanvasRenderer:
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 32
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0

--- a/OrbitLearn/Assets/Scenes/PresetSimScene.unity
+++ b/OrbitLearn/Assets/Scenes/PresetSimScene.unity
@@ -477,12 +477,12 @@ PrefabInstance:
     - target: {fileID: 460939560846785174, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 23.8077
+      value: 23.807709
       objectReference: {fileID: 0}
     - target: {fileID: 460939560846785174, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0.08049965
+      value: 0.08049774
       objectReference: {fileID: 0}
     - target: {fileID: 1707403802545233896, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
@@ -2045,7 +2045,7 @@ PrefabInstance:
     - target: {fileID: 1376227493220696949, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 1474.9756
+      value: 175
       objectReference: {fileID: 0}
     - target: {fileID: 1376227493220696949, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -2055,7 +2055,7 @@ PrefabInstance:
     - target: {fileID: 1376227493220696949, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -737.48804
+      value: -87.5
       objectReference: {fileID: 0}
     - target: {fileID: 2883205230598049634, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -2130,17 +2130,27 @@ PrefabInstance:
     - target: {fileID: 4101135871847186900, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4101135871847186900, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4101135871847186900, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0.7396774
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4101135871847186900, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 81
+      objectReference: {fileID: 0}
+    - target: {fileID: 4101135871847186900, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -64
       objectReference: {fileID: 0}
     - target: {fileID: 5276716799211018903, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -2150,7 +2160,7 @@ PrefabInstance:
     - target: {fileID: 5276716799211018903, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5744187795873587029, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -2265,7 +2275,7 @@ PrefabInstance:
     - target: {fileID: 7045803773692108309, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_margin.w
-      value: -44.47766
+      value: -44.480713
       objectReference: {fileID: 0}
     - target: {fileID: 7045803773692108309, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -2294,13 +2304,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7705168930619218856, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 38
+      objectReference: {fileID: 0}
+    - target: {fileID: 7705168930619218856, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 267
       objectReference: {fileID: 0}
     - target: {fileID: 7705168930619218856, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 7
+      value: -52
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fe740d39a5c3e004489c7889b1b4def7, type: 3}
@@ -3268,12 +3283,12 @@ PrefabInstance:
     - target: {fileID: 460939560846785174, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 27.667
+      value: 27.666992
       objectReference: {fileID: 0}
     - target: {fileID: 460939560846785174, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.000009536743
+      value: -0.0000076293945
       objectReference: {fileID: 0}
     - target: {fileID: 1707403802545233896, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
@@ -3677,12 +3692,12 @@ PrefabInstance:
     - target: {fileID: 460939560846785174, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 21.4871
+      value: 21.487091
       objectReference: {fileID: 0}
     - target: {fileID: 460939560846785174, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.00005531311
+      value: -0.00005340576
       objectReference: {fileID: 0}
     - target: {fileID: 1707403802545233896, guid: 47a684e0e79aa684b9aa0fab56749b1a,
         type: 3}

--- a/OrbitLearn/Assets/Scenes/SimulationScene.unity
+++ b/OrbitLearn/Assets/Scenes/SimulationScene.unity
@@ -1597,7 +1597,7 @@ PrefabInstance:
     - target: {fileID: 1376227493220696949, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 1474.9756
+      value: 0.00390625
       objectReference: {fileID: 0}
     - target: {fileID: 1376227493220696949, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -1607,7 +1607,7 @@ PrefabInstance:
     - target: {fileID: 1376227493220696949, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -737.4839
+      value: 0.001953125
       objectReference: {fileID: 0}
     - target: {fileID: 2883205230598049634, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -1836,13 +1836,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7045803773692108309, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
+      propertyPath: m_margin.w
+      value: 1579.7416
+      objectReference: {fileID: 0}
+    - target: {fileID: 7045803773692108309, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
       propertyPath: m_margin.x
       value: 26.518158
       objectReference: {fileID: 0}
     - target: {fileID: 7045803773692108309, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_margin.y
-      value: 1.3386236
+      value: 25.261581
       objectReference: {fileID: 0}
     - target: {fileID: 7045803773692108309, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}

--- a/OrbitLearn/Assets/Scenes/SimulationScene.unity
+++ b/OrbitLearn/Assets/Scenes/SimulationScene.unity
@@ -1569,6 +1569,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 96664987}
     m_Modifications:
+    - target: {fileID: 843454303821627374, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 1376227493220696949, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -1679,6 +1684,11 @@ PrefabInstance:
       propertyPath: gameManagerReference
       value: 
       objectReference: {fileID: 0}
+    - target: {fileID: 3520819647165824174, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 4101135871847186900, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -1693,6 +1703,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4145944047463803804, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 4195008964368606456, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -1714,10 +1729,25 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -104.17926
       objectReference: {fileID: 0}
+    - target: {fileID: 4409880081761198346, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4844318832401940977, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 5276716799211018903, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_Name
       value: Body_List_Panel
+      objectReference: {fileID: 0}
+    - target: {fileID: 5276716799211018903, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5276716799211018903, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
@@ -1829,6 +1859,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5843176387444877497, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 7045803773692108309, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}
       propertyPath: m_text
@@ -1853,6 +1888,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_margin.z
       value: 137.65816
+      objectReference: {fileID: 0}
+    - target: {fileID: 7288176691393523147, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7613331000827293840, guid: fe740d39a5c3e004489c7889b1b4def7,
+        type: 3}
+      propertyPath: m_Layer
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 7705168930619218856, guid: fe740d39a5c3e004489c7889b1b4def7,
         type: 3}

--- a/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
+++ b/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
@@ -71,12 +71,12 @@ public class BodiesInfoButton : MonoBehaviour
             screenplier = 2195 * screenplier;
             xPosition = 465;
         }
-        
-        
+
+
         //1.778 is the ratio of height to width that has a favored starting offset.
         // this needs to and accounts for different phone sizes for button initial offset.
-       
 
+        int bodyNullDisplayCounter = 1;
         for (int loopCount = 0;loopCount<count;loopCount++)
         {
             int num = loopCount;
@@ -87,12 +87,20 @@ public class BodiesInfoButton : MonoBehaviour
 
             //Debug.Log(panelExpansionCount + " panelExpansionCount!", this);
             button.GetComponent<RectTransform>().anchoredPosition = new Vector2(xPosition, -372 *(loopCount - panelExpansionCount) + screenplier + (float)7.8 * panelExpansionCount);//Changing text
-                
-          
 
-            button.GetComponentInChildren<TMP_Text>().text = "Body " + (loopCount+1)+": \n"+ tmp[loopCount].bodyName;
+
+            if (tmp[num].bodyName == "")
+            {
+                tmp[num].bodyName = "Body " + bodyNullDisplayCounter;
+            }
+            else
+            {
+                bodyNullDisplayCounter--;
+            }
+            button.GetComponentInChildren<TMP_Text>().text = tmp[num].bodyName;
             Buttons.Add(button);
             buttonCount++;
+            bodyNullDisplayCounter++;
             //////
         }
     }
@@ -126,7 +134,8 @@ public class BodiesInfoButton : MonoBehaviour
         int count = 1;
         foreach (Body b in gameManagerReference.SimBodies)
         {
-            totalDisplay += "<u><b>Body Name: " +b.bodyName + "</u></b>\n";
+            totalDisplay += "<u><b>Body Name:</u></b>\n" + b.bodyName +"\n";
+          
             totalDisplay += returnText(b, 3);
             totalDisplay += returnText(b, 0);
             totalDisplay+= returnText(b, 1);
@@ -136,20 +145,24 @@ public class BodiesInfoButton : MonoBehaviour
         return totalDisplay;
 
     }
+
+
+
+
     public string returnText(Body b, int mode)
     {
         string shipped = "";
         switch (mode)
         {
             case 0:
-                shipped += "X Velocity: " + b.returnRigBody().velocity.x.ToString("#.00") + "m/s\n"+ "Y Velocity: " + b.returnRigBody().velocity.y.ToString("#.00") + "m/s\n" + "Z Velocity: " + b.returnRigBody().velocity.z.ToString("#.00") + "m/s\n";
+                shipped += "X Velocity: " + b.returnRigBody().velocity.x.ToString("#.00") + "m/s\n"+ "Y Velocity: " + b.returnRigBody().velocity.y.ToString("#.00") + "m/s\n" + "Z Velocity: " + b.returnRigBody().velocity.z.ToString("#.00") + "m/s\n\n";
                 break;
             case 1:
                 shipped += "X Position: " + b.gameObject.transform.position.x.ToString("#.00") + "m\n" + "Y Position: " + b.gameObject.transform.position.y.ToString("#.00") + "m\n" + "Z Position: " + b.gameObject.transform.position.z.ToString("#.00") + "m\n";
 
                 break;
             default:
-                shipped += "Mass " + b.returnRigBody().mass.ToString("E2") + "kg\n";
+                shipped += "Mass " + b.returnRigBody().mass.ToString("E2") + "kg\n\n";
                 break;
         }
         return shipped;

--- a/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
+++ b/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
@@ -136,8 +136,14 @@ public class BodiesInfoButton : MonoBehaviour
             buttonSpawn = 1;
             spawnButtons(knownBodyCount);
         }
-
         string totalDisplay = "";
+        if (knownBodyCount == 0)
+        {
+            totalDisplay += "No Bodies are currently displayed. Please add a body for their information to be displayed promply here.";
+        }
+
+
+        
         int count = 1;
         foreach (Body b in gameManagerReference.SimBodies)
         {

--- a/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
+++ b/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
@@ -72,7 +72,11 @@ public class BodiesInfoButton : MonoBehaviour
             xPosition = 465;
         }
 
+        float baseHeightDisplay = 150, baseWidthDisplay = 320;
+        float textSizeIndex = (float)320/68;
 
+        float offsetHeight = baseHeightDisplay * (float)Screen.height / 1920;
+        float offsetWidth = baseWidthDisplay * (float)Screen.width / 1080;
         //1.778 is the ratio of height to width that has a favored starting offset.
         // this needs to and accounts for different phone sizes for button initial offset.
 
@@ -87,7 +91,7 @@ public class BodiesInfoButton : MonoBehaviour
 
             //Debug.Log(panelExpansionCount + " panelExpansionCount!", this);
             button.GetComponent<RectTransform>().anchoredPosition = new Vector2(xPosition, -372 *(loopCount - panelExpansionCount) + screenplier + (float)7.8 * panelExpansionCount);//Changing text
-
+            button.GetComponent<RectTransform>().sizeDelta = new Vector2(offsetWidth, offsetHeight);
 
             if (tmp[num].bodyName == "")
             {
@@ -98,6 +102,7 @@ public class BodiesInfoButton : MonoBehaviour
                 bodyNullDisplayCounter--;
             }
             button.GetComponentInChildren<TMP_Text>().text = tmp[num].bodyName;
+            button.GetComponentInChildren<TMP_Text>().fontSize = offsetWidth/textSizeIndex;//((float)Screen.width * (float)Screen.height) / (baseHeightDisplay * baseWidthDisplay);
             Buttons.Add(button);
             buttonCount++;
             bodyNullDisplayCounter++;

--- a/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
+++ b/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
@@ -15,6 +15,7 @@ public class BodiesInfoButton : MonoBehaviour
     public int panelExpansionCount = 0;
     public int buttonCount = 0;
     public int presetFilm = 0;
+    public int defaultBodyCountDisplayNum = 1;
     public List<GameObject> Buttons;
 
     [Header("Input Field References")]
@@ -80,7 +81,7 @@ public class BodiesInfoButton : MonoBehaviour
         //1.778 is the ratio of height to width that has a favored starting offset.
         // this needs to and accounts for different phone sizes for button initial offset.
 
-        int bodyNullDisplayCounter = 1;
+
         for (int loopCount = 0;loopCount<count;loopCount++)
         {
             int num = loopCount;
@@ -89,23 +90,24 @@ public class BodiesInfoButton : MonoBehaviour
             button.GetComponent<Button>().onClick.AddListener(() => FocusOnPlanet(num));
             button.transform.SetParent(buttonPanel.transform);//Setting button parent
 
-            //Debug.Log(panelExpansionCount + " panelExpansionCount!", this);
-            button.GetComponent<RectTransform>().anchoredPosition = new Vector2(xPosition, -372 *(loopCount - panelExpansionCount) + screenplier + (float)7.8 * panelExpansionCount);//Changing text
+            //Debug.Log(panelExpansionCount + " panelExpansionCount!", this);//372
+            button.GetComponent<RectTransform>().anchoredPosition = new Vector2(xPosition, -450 *(loopCount - panelExpansionCount) + screenplier + (float)7.8 * panelExpansionCount);//Changing text
             button.GetComponent<RectTransform>().sizeDelta = new Vector2(offsetWidth, offsetHeight);
 
             if (tmp[num].bodyName == "")
             {
-                tmp[num].bodyName = "Body " + bodyNullDisplayCounter;
+                tmp[num].bodyName = "Body " + defaultBodyCountDisplayNum;
+                defaultBodyCountDisplayNum++;
             }
-            else
+           /* else
             {
                 bodyNullDisplayCounter--;
-            }
+            }*/
             button.GetComponentInChildren<TMP_Text>().text = tmp[num].bodyName;
             button.GetComponentInChildren<TMP_Text>().fontSize = offsetWidth/textSizeIndex;//((float)Screen.width * (float)Screen.height) / (baseHeightDisplay * baseWidthDisplay);
             Buttons.Add(button);
             buttonCount++;
-            bodyNullDisplayCounter++;
+            
             //////
         }
     }
@@ -139,7 +141,7 @@ public class BodiesInfoButton : MonoBehaviour
         int count = 1;
         foreach (Body b in gameManagerReference.SimBodies)
         {
-            totalDisplay += "<u><b>Body Name:</u></b>\n" + b.bodyName +"\n";
+            totalDisplay += "<u><b>Body Name:</u></b> " + b.bodyName +"\n";
           
             totalDisplay += returnText(b, 3);
             totalDisplay += returnText(b, 0);

--- a/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
+++ b/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
@@ -48,7 +48,7 @@ public class BodiesInfoButton : MonoBehaviour
     }
     public int calculateStepHeight()
     {//DO NOT CHANGE THE MATHHHHHH OR YOU WILL BE SORRY
-        return gameManagerReference.BodyCount - 6 - panelLastCount;
+        return gameManagerReference.BodyCount - 1 - panelLastCount;//- 6 -
 
     }
     public void spawnButtons(int count)
@@ -115,16 +115,16 @@ public class BodiesInfoButton : MonoBehaviour
     { //DO NOT CHANGE THE MATHHHHHH OR YOU WILL BE SORRY
         int knownBodyCount = gameManagerReference.BodyCount;
        
-        if (gameManagerReference.BodyCount > 6 && panelExpansion ==0)
+        if (gameManagerReference.BodyCount > 1 && panelExpansion ==0)
         {
             panelExpansion = 1;
             
             panelRedaction = calculateStepHeight();
             if (panelRedaction > 0)
             {
-                displayTxt.GetComponent<RectTransform>().offsetMin += new Vector2(0, (panelRedaction) * -380);
+                displayTxt.GetComponent<RectTransform>().offsetMin += new Vector2(0, (panelRedaction) * -458);
                 panelExpansionCount+= panelRedaction;
-                panelLastCount = gameManagerReference.BodyCount -6;
+                panelLastCount = gameManagerReference.BodyCount -1;
             }
 
            

--- a/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
+++ b/OrbitLearn/Assets/Scripts/BodiesInfoButton.cs
@@ -60,7 +60,7 @@ public class BodiesInfoButton : MonoBehaviour
         }
         float screenplier = ((((float)Screen.height) / ((float)Screen.width)) / ((float)1920/1080));
         screenplier = screenplier - 2 * (screenplier - 1) / 5;
-        int xPosition = 422;
+        int xPosition = 412;
 
         if (presetFilm == 1)
         {
@@ -91,7 +91,7 @@ public class BodiesInfoButton : MonoBehaviour
             button.transform.SetParent(buttonPanel.transform);//Setting button parent
 
             //Debug.Log(panelExpansionCount + " panelExpansionCount!", this);//372
-            button.GetComponent<RectTransform>().anchoredPosition = new Vector2(xPosition, -450 *(loopCount - panelExpansionCount) + screenplier + (float)7.8 * panelExpansionCount);//Changing text
+            button.GetComponent<RectTransform>().anchoredPosition = new Vector2(xPosition, (float)-455.5 * (loopCount - panelExpansionCount) - 1500 + screenplier + (float)2.8 * panelExpansionCount);//Changing text
             button.GetComponent<RectTransform>().sizeDelta = new Vector2(offsetWidth, offsetHeight);
 
             if (tmp[num].bodyName == "")

--- a/OrbitLearn/Assets/Scripts/GameManager.cs
+++ b/OrbitLearn/Assets/Scripts/GameManager.cs
@@ -253,7 +253,7 @@ public class GameManager : MonoBehaviour
 
         Destroy(b.gameObject);
 
-        BodyCount--;
+        
         BodyInfoPanel.ClearHighlightedBody();
         BodyInfoPanel.gameObject.SetActive(false);
     }


### PR DESCRIPTION
Needs an Overhaul 2, for the following:
What is needed:
Panel reduces when bodies are deleted.
Math and placement overhaul for text and button allignment (rn using legacy code approximations)
Prioritize panel over the game screen, so bodies cant be clicked while panel is open
Somehow make the preset bodies panel text carrier wider. This thing is a bitch f the preset world.

But considering all below got done, now was a good time for a merge:
Bug patch on bodies panel where body buttons would not spawn when reset button was pushed.
Bodies buttons grow and shrink with the size of the screen size they are spawned on. ALL portrait sizes are testable now, whereas previous 800 x 500 and 1280 x 700 were not testable. Now. Nowone should have phones of this size but if they do now they can do stuff.
Body buttons are no longer thiccc
Body button names (text) grows and shrinks with the width of the button it spawns in.
Body panel no longer has long scroll when initiated. Scroll increases with every body spawned now, instead of the previous amount.
Body panel now displays default text when no bodies are present
Other minor changes to cope with the preset sim body panel were also made, along with UI changes, etc.
Game manager was edited for the bug patch.

