### PR TITLE
Camera Movement is disabled when the bodies panel or the add body panel is act…

### DIFF
--- a/OrbitLearn/Assets/Scripts/MoveCameraOnTouch.cs
+++ b/OrbitLearn/Assets/Scripts/MoveCameraOnTouch.cs
@@ -15,9 +15,9 @@ public class MoveCameraOnTouch: MonoBehaviour
     {
         //Touch touch = Input.GetTouch(0);
 
-        if (axisName == "Mouse X")
+        if (axisName == "Mouse X" )
         {
-            if (Input.GetMouseButton(0))
+            if (Input.GetMouseButton(0)&& !GameManager.Instance.uiPanelPriority)
             {
                 return UnityEngine.Input.GetAxis("Mouse X");
             }
@@ -28,7 +28,7 @@ public class MoveCameraOnTouch: MonoBehaviour
         }
         else if (axisName == "Mouse Y")
         {
-            if (Input.GetMouseButton(0))
+            if (Input.GetMouseButton(0) && !GameManager.Instance.uiPanelPriority)
             {
                 return UnityEngine.Input.GetAxis("Mouse Y");
             }


### PR DESCRIPTION
Camera movement is disabled when bodies panel, preset sim panel, or add body panel is active. This combined with the update in Bodies panel overhaul 2 make it to where whenever either of the mentioned panels are open, you can only interact with that panel. This was not done for the panel slider, or the body info pane since i personally believe interacting with bodies while those are up fits better with interaction.