### PR TITLE
Feature bug patches2

### DIFF
--- a/OrbitLearn/Assets/Scenes/EquationScene.unity
+++ b/OrbitLearn/Assets/Scenes/EquationScene.unity
@@ -387,6 +387,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 806173740}
+        m_TargetAssemblyTypeName: MainMenu, Assembly-CSharp
+        m_MethodName: ShowIdleMenu
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &155332635
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -842,6 +854,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a367ebc74bc9484d96d30b53b53698d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  StartSim: {fileID: 0}
+  Info: {fileID: 0}
+  Equations: {fileID: 0}
+  MenuMain: {fileID: 155332634}
+  isOpen: 1
 --- !u!1 &1188132335
 GameObject:
   m_ObjectHideFlags: 0
@@ -925,7 +942,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 2074230003}
   m_Direction: 2
   m_Value: 0.9994874
-  m_Size: 0.34094596
+  m_Size: 0.34094593
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:

--- a/OrbitLearn/Assets/Scenes/HomeScene.unity
+++ b/OrbitLearn/Assets/Scenes/HomeScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.0014371083, g: 0.001384888, b: 0.0013701947, a: 1}
+  m_IndirectSpecularColor: {r: 0.0014415674, g: 0.0013888229, b: 0.0013739478, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -456,6 +456,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a367ebc74bc9484d96d30b53b53698d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  StartSim: {fileID: 0}
+  Info: {fileID: 0}
+  Equations: {fileID: 0}
+  isOpen: 1
 --- !u!1 &869171149
 GameObject:
   m_ObjectHideFlags: 0
@@ -640,6 +644,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 862784579}
     m_Modifications:
+    - target: {fileID: 4926995792374354335, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: Info
+      value: 
+      objectReference: {fileID: 1118374316}
+    - target: {fileID: 4926995792374354335, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: StartSim
+      value: 
+      objectReference: {fileID: 1118374317}
+    - target: {fileID: 4926995792374354335, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: Equations
+      value: 
+      objectReference: {fileID: 1118374315}
     - target: {fileID: 9024307252260515686, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
         type: 3}
       propertyPath: m_Text
@@ -825,6 +844,46 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 418
       objectReference: {fileID: 0}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1118374314}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: ShowIdleMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: MainMenu, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_StringArgument
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 9024307252783168538, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
         type: 3}
       propertyPath: m_Type
@@ -910,6 +969,41 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 145.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1118374314}
+    - target: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: ShowIdleMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: MainMenu, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 9024307253014757646, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
         type: 3}
@@ -998,6 +1092,41 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 279.5
       objectReference: {fileID: 0}
+    - target: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1118374314}
+    - target: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: ShowIdleMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: MainMenu, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 9024307253669533335, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
         type: 3}
       propertyPath: m_Type
@@ -1057,6 +1186,42 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1a367ebc74bc9484d96d30b53b53698d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1118374315 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9024307253014757645, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1118374313}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1118374316 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9024307253669533334, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1118374313}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1118374317 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9024307252783168537, guid: 30dfdf8d91a878a4dbcbb75e70467f7f,
+    type: 3}
+  m_PrefabInstance: {fileID: 1118374313}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1225138534

--- a/OrbitLearn/Assets/Scenes/InfoScene.unity
+++ b/OrbitLearn/Assets/Scenes/InfoScene.unity
@@ -560,6 +560,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1087425052}
+        m_TargetAssemblyTypeName: MainMenu, Assembly-CSharp
+        m_MethodName: ShowIdleMenu
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &269245791
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -856,6 +868,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a367ebc74bc9484d96d30b53b53698d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  StartSim: {fileID: 0}
+  Info: {fileID: 0}
+  Equations: {fileID: 0}
+  MenuMain: {fileID: 269245790}
+  isOpen: 1
 --- !u!1 &1112923230
 GameObject:
   m_ObjectHideFlags: 0

--- a/OrbitLearn/Assets/Scripts/Body.cs
+++ b/OrbitLearn/Assets/Scripts/Body.cs
@@ -71,4 +71,16 @@ public class Body : MonoBehaviour
     {
         return body.layer;
     }
+
+    public bool IsEqual(Body comparer)
+    {
+        if (comparer.bodyNumber == this.bodyNumber)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
 }

--- a/OrbitLearn/Assets/Scripts/GameManager.cs
+++ b/OrbitLearn/Assets/Scripts/GameManager.cs
@@ -226,9 +226,9 @@ public class GameManager : MonoBehaviour
                         if (b != null)
                         {
                             //If the active body has been tapped, do [thing]
-                            if (b == focusedBody)
+                            if (b.IsEqual(focusedBody))
                             {
-
+                                ShowBodyInfo(b);
                             }
                             //If a body other than the active planet has been tapped (likely erroneously), do nothing
                             else
@@ -242,15 +242,18 @@ public class GameManager : MonoBehaviour
                 //If empty space is tapped...
                 else
                 {
+                    HideBodyInfo();
                     //...check for a doubletap. If doubletap, zoom out and clear the screen.
                     if (doubleTapReady)
                     {
-                        focusedBody = null;
+                        
                         HideBodyInfo();
                         if (UniverseCam != null)
                         {
+                            focusedBody = null;
                             ActivateUniverseCam();
                         }
+                        //doubleTapReady = false;
                     }
                     else
                     {
@@ -268,7 +271,7 @@ public class GameManager : MonoBehaviour
     {
         Debug.Log("New run of Doubletap()");
         doubleTapReady = true;
-        yield return new WaitForSeconds(0.75f);
+        yield return new WaitForSecondsRealtime(0.75f);
         doubleTapReady = false;
     }
 
@@ -533,10 +536,8 @@ public class GameManager : MonoBehaviour
     }
     public IEnumerator HintPanelDelay(string msg1, string msg2)
     {
-        if (!gamePaused)
-        {
-            yield return new WaitForSeconds(0.13f);
-        }
+        yield return new WaitForSecondsRealtime(0.13f);
+        
         
         if (!uiPanelPriority&&UniverseCam.Priority == 4)
         {
@@ -884,10 +885,8 @@ public class GameManager : MonoBehaviour
 
     private IEnumerator MaybeShowIdleMenu()
     {
-        if (!gamePaused)
-        {
-            yield return new WaitForSeconds(0.15f);
-        }
+        yield return new WaitForSecondsRealtime(0.15f);
+        
         
         if (SliderMenu.isOpen)
         {
@@ -898,19 +897,17 @@ public class GameManager : MonoBehaviour
     }
     private IEnumerator BodyInfoPanelDisplay()
     {
-        if (!gamePaused)
-        {
-            yield return new WaitForSeconds(0.13f);
-        }
+        yield return new WaitForSecondsRealtime(0.13f);
+        
         
         if (!uiPanelPriority&&UniverseCam.Priority == 4)
         {
             BodyInfoPanel.gameObject.SetActive(true);
         }
-        else if (gamePaused && !BodiesPanel.noBodyVerified && uiPanelPriority)
+        /*else if (gamePaused && !BodiesPanel.noBodyVerified && uiPanelPriority)
         {
             BodyInfoPanel.gameObject.SetActive(true);
-        }
+        }*/
     }
 
     //Displays the Body Info Panel for the input Body
@@ -935,7 +932,7 @@ public class GameManager : MonoBehaviour
         if (BodyInfoPanel != null)
         {
             BodyInfoPanel.ClearHighlightedBody();
-            focusedBody = null;
+           // focusedBody = null;
             BodyInfoPanel.gameObject.SetActive(false);
         }
         if (HintDisplay != null)

--- a/OrbitLearn/Assets/Scripts/GameManager.cs
+++ b/OrbitLearn/Assets/Scripts/GameManager.cs
@@ -349,11 +349,18 @@ public class GameManager : MonoBehaviour
             Rigidbody r = b.gameObject.GetComponent<Rigidbody>();
             b.transform.position = new Vector3((float)xLoc, (float)yLoc, (float)zLoc);
             b.transform.localScale = new Vector3((float)scal, (float)scal, (float)scal);
+
             bodyRef.bodyName = name;
+
             float camOrbit = (float)((scal * 8) + 27) / 7;
             bodyRef.planetCam.m_Orbits[0] = new CinemachineFreeLook.Orbit(camOrbit, 0.1f);
             bodyRef.planetCam.m_Orbits[1] = new CinemachineFreeLook.Orbit(0, camOrbit);
             bodyRef.planetCam.m_Orbits[2] = new CinemachineFreeLook.Orbit(-camOrbit, 0.1f);
+
+            bodyRef.planetCam.m_XAxis.m_SpeedMode = (Cinemachine.AxisState.SpeedMode)1;
+            bodyRef.planetCam.m_YAxis.m_SpeedMode = (Cinemachine.AxisState.SpeedMode)1;
+            bodyRef.planetCam.m_YAxis.m_MaxSpeed = 0.1f;
+            bodyRef.planetCam.m_XAxis.m_MaxSpeed = 15f;
 
             r.mass = (float)mass;
             r.velocity = (new Vector3((float)xVel, (float)yVel, (float)zVel));

--- a/OrbitLearn/Assets/Scripts/GameManager.cs
+++ b/OrbitLearn/Assets/Scripts/GameManager.cs
@@ -195,8 +195,9 @@ public class GameManager : MonoBehaviour
                         //If the body component exists, then zoom in and display relevant information.
                         if (b != null)
                         {
-                            ShowBodyInfo(b);
+                            
                             ActivateBodyCam(b.planetCam);
+                            ShowBodyInfo(b);
                         }
                     }
                 }
@@ -537,7 +538,12 @@ public class GameManager : MonoBehaviour
             yield return new WaitForSeconds(0.13f);
         }
         
-        if (!uiPanelPriority)
+        if (!uiPanelPriority&&UniverseCam.Priority == 4)
+        {
+            HintDisplay.gameObject.SetActive(true);
+            HintDisplay.SetMessageText(msg1, msg2);
+        }
+        else if (gamePaused && !BodiesPanel.noBodyVerified && uiPanelPriority)
         {
             HintDisplay.gameObject.SetActive(true);
             HintDisplay.SetMessageText(msg1, msg2);
@@ -897,7 +903,11 @@ public class GameManager : MonoBehaviour
             yield return new WaitForSeconds(0.13f);
         }
         
-        if (!uiPanelPriority)
+        if (!uiPanelPriority&&UniverseCam.Priority == 4)
+        {
+            BodyInfoPanel.gameObject.SetActive(true);
+        }
+        else if (gamePaused && !BodiesPanel.noBodyVerified && uiPanelPriority)
         {
             BodyInfoPanel.gameObject.SetActive(true);
         }

--- a/OrbitLearn/Assets/Scripts/GameManager.cs
+++ b/OrbitLearn/Assets/Scripts/GameManager.cs
@@ -558,18 +558,16 @@ public class GameManager : MonoBehaviour
     }
     public IEnumerator HintPanelDelay(string msg1, string msg2)
     {
-        yield return new WaitForSecondsRealtime(0.13f);
+        yield return new WaitForSecondsRealtime(0.17f);
         
         
         if (!uiPanelPriority&&UniverseCam.Priority == 4)
         {
-            HintDisplay.gameObject.SetActive(true);
-            HintDisplay.SetMessageText(msg1, msg2);
-        }
-        else if (gamePaused && !BodiesPanel.noBodyVerified && uiPanelPriority)
-        {
-            HintDisplay.gameObject.SetActive(true);
-            HintDisplay.SetMessageText(msg1, msg2);
+            if (!SliderMenu.isOpen)
+            {
+                HintDisplay.gameObject.SetActive(true);
+                HintDisplay.SetMessageText(msg1, msg2);
+            }
         }
     }
 
@@ -924,12 +922,15 @@ public class GameManager : MonoBehaviour
     }
     private IEnumerator BodyInfoPanelDisplay()
     {
-        yield return new WaitForSecondsRealtime(0.13f);
+        yield return new WaitForSecondsRealtime(0.17f);
         
         
         if (!uiPanelPriority&&UniverseCam.Priority == 4)
         {
-            BodyInfoPanel.gameObject.SetActive(true);
+            if (!SliderMenu.isOpen)
+            {
+                BodyInfoPanel.gameObject.SetActive(true);
+            }
         }
         /*else if (gamePaused && !BodiesPanel.noBodyVerified && uiPanelPriority)
         {

--- a/OrbitLearn/Assets/Scripts/GameManager.cs
+++ b/OrbitLearn/Assets/Scripts/GameManager.cs
@@ -228,12 +228,23 @@ public class GameManager : MonoBehaviour
                             //If the active body has been tapped, do [thing]
                             if (b.IsEqual(focusedBody))
                             {
-                                ShowBodyInfo(b);
+                                Debug.Log("KeptHittingDis");
+                                if (!BodyInfoPanel.gameObject.activeSelf)
+                                {
+                                    ShowBodyInfo(b);
+
+                                    SetHintPanel();
+                                }
                             }
                             //If a body other than the active planet has been tapped (likely erroneously), do nothing
                             else
                             {
                                 //lol
+                                HideHintMessage();
+                                HideBodyInfo();
+                                ActivateUniverseCam();
+                                ActivateBodyCam(b.planetCam);
+                                ShowBodyInfo(b);
                             }
                         }
                     }
@@ -242,7 +253,7 @@ public class GameManager : MonoBehaviour
                 //If empty space is tapped...
                 else
                 {
-                    HideBodyInfo();
+                    StartCoroutine(DelayedHidePanel());
                     //...check for a doubletap. If doubletap, zoom out and clear the screen.
                     if (doubleTapReady)
                     {
@@ -275,7 +286,11 @@ public class GameManager : MonoBehaviour
         doubleTapReady = false;
     }
 
-
+    public IEnumerator DelayedHidePanel()
+    {
+        yield return new WaitForSecondsRealtime(0.13f);
+        HideBodyInfo();
+    }
 
     //uses a fixed update cycle to keep physics consistent
     void FixedUpdate()
@@ -642,16 +657,12 @@ public class GameManager : MonoBehaviour
     #region Camera Functions
     //Changes the priority to favor a particular planet cam over the universe cam
     
-    public void ActivateBodyCam(CinemachineFreeLook cam)
+    public void SetHintPanel()
     {
-        cam.Priority = 5;
-        ActivePlanetCam = cam;
-        UniverseCam.Priority = 4;
-        CurrCamState = CamState.Body;
         int ran = UnityEngine.Random.Range(0, factCollisions.Length - 1);
 
         hashObject.ChangeKey(ran);
-        
+
         if (bodyClickCount > 0)
         {
             if (highLoadBalance > .70)
@@ -668,6 +679,15 @@ public class GameManager : MonoBehaviour
             DisplayHintMessage("Tap twice outside of the body to unfocus.", "");
         }
         bodyClickCount++;
+    }
+
+    public void ActivateBodyCam(CinemachineFreeLook cam)
+    {
+        cam.Priority = 5;
+        ActivePlanetCam = cam;
+        UniverseCam.Priority = 4;
+        CurrCamState = CamState.Body;
+        SetHintPanel();
     }
 
     //Changes the priority to favor the universe over a particular planet

--- a/OrbitLearn/Assets/Scripts/MainMenu.cs
+++ b/OrbitLearn/Assets/Scripts/MainMenu.cs
@@ -20,6 +20,7 @@ public class MainMenu : MonoBehaviour
     public Button StartSim;
     public Button Info;
     public Button Equations;
+    public Button MenuMain;
 
     public bool isOpen = true;
 
@@ -74,6 +75,11 @@ public class MainMenu : MonoBehaviour
         {
             Equations.interactable = isOpen;
         }
+        if (MenuMain != null)
+        {
+            MenuMain.interactable = isOpen;
+        }
+
     }
 
     //Triggers the panel sliding in/out of the frame

--- a/OrbitLearn/Assets/Scripts/MainMenu.cs
+++ b/OrbitLearn/Assets/Scripts/MainMenu.cs
@@ -10,12 +10,18 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class MainMenu : MonoBehaviour
 {
 
     private GameManager gameManagerReference;
 
+    public Button StartSim;
+    public Button Info;
+    public Button Equations;
+
+    public bool isOpen = true;
 
     private void Awake()
     {
@@ -51,6 +57,30 @@ public class MainMenu : MonoBehaviour
     public void LoadEquationsScene()
     {
         gameManagerReference.LoadNewScene(SceneHandler.Scene.EquationScene);
+    }
+
+
+    public void ChangeButtonInteractability()
+    {
+        if (StartSim != null)
+        {
+            StartSim.interactable = isOpen;
+        }
+        if (Info != null)
+        {
+            Info.interactable = isOpen;
+        }
+        if (Equations != null)
+        {
+            Equations.interactable = isOpen;
+        }
+    }
+
+    //Triggers the panel sliding in/out of the frame
+    public void ShowIdleMenu()
+    {
+        isOpen = !isOpen;
+        ChangeButtonInteractability();
     }
 
     //Here lies former preset sim load.

--- a/OrbitLearn/Assets/Scripts/MoveCameraOnTouch.cs
+++ b/OrbitLearn/Assets/Scripts/MoveCameraOnTouch.cs
@@ -18,10 +18,18 @@ public class MoveCameraOnTouch : MonoBehaviour
         if (Input.GetMouseButton(0) && !GameManager.Instance.uiPanelPriority)
         {
             var FreeLookComponent = VitFreeLook.GetComponent<CinemachineFreeLook>();
-            if (Input.touchCount > 0)
+            if (GameManager.Instance.gamePaused)
+            {
+                FreeLookComponent.m_YAxis.m_MaxSpeed = 0.05f;
+                FreeLookComponent.m_XAxis.m_MaxSpeed = 7.5f;
+            }
+            else
             {
                 FreeLookComponent.m_YAxis.m_MaxSpeed = 0.1f;
                 FreeLookComponent.m_XAxis.m_MaxSpeed = 15f;
+            }
+            if (Input.touchCount > 0)
+            {
                 switch (axisName)
                 {
                     case "Mouse X":
@@ -35,16 +43,6 @@ public class MoveCameraOnTouch : MonoBehaviour
             }
             else
             {
-                if (GameManager.Instance.gamePaused)
-                {
-                    FreeLookComponent.m_YAxis.m_MaxSpeed = 0.005f;
-                    FreeLookComponent.m_XAxis.m_MaxSpeed = 1.5f;
-                }
-                else
-                {
-                    FreeLookComponent.m_YAxis.m_MaxSpeed = 0.1f;
-                    FreeLookComponent.m_XAxis.m_MaxSpeed = 15f;
-                }
                 return Input.GetAxis(axisName);
             }
         }

--- a/OrbitLearn/Assets/Scripts/MoveCameraOnTouch.cs
+++ b/OrbitLearn/Assets/Scripts/MoveCameraOnTouch.cs
@@ -18,20 +18,10 @@ public class MoveCameraOnTouch : MonoBehaviour
         if (Input.GetMouseButton(0) && !GameManager.Instance.uiPanelPriority)
         {
             var FreeLookComponent = VitFreeLook.GetComponent<CinemachineFreeLook>();
-
-            if (GameManager.Instance.gamePaused)
-            {
-                FreeLookComponent.m_YAxis.m_MaxSpeed = 0.005f;
-                FreeLookComponent.m_XAxis.m_MaxSpeed = 1.5f;
-            }
-            else
+            if (Input.touchCount > 0)
             {
                 FreeLookComponent.m_YAxis.m_MaxSpeed = 0.1f;
                 FreeLookComponent.m_XAxis.m_MaxSpeed = 15f;
-            }
-
-            if (Input.touchCount > 0)
-            {
                 switch (axisName)
                 {
                     case "Mouse X":
@@ -45,6 +35,16 @@ public class MoveCameraOnTouch : MonoBehaviour
             }
             else
             {
+                if (GameManager.Instance.gamePaused)
+                {
+                    FreeLookComponent.m_YAxis.m_MaxSpeed = 0.005f;
+                    FreeLookComponent.m_XAxis.m_MaxSpeed = 1.5f;
+                }
+                else
+                {
+                    FreeLookComponent.m_YAxis.m_MaxSpeed = 0.1f;
+                    FreeLookComponent.m_XAxis.m_MaxSpeed = 15f;
+                }
                 return Input.GetAxis(axisName);
             }
         }


### PR DESCRIPTION
Numerous Panel overlay minor bugs. 
Camera speeds adjusted for when paused. 
All body cameras now implement the same functionality as the universe camera (input value gain). 
Bug where clicking on body in the bodies panel when the simulation was paused not displaying body info pane is fixed.
Users can now reclick on bodies and see info pane and hint pane when zoomed in on body.
Body camera zooming out on 1 click when simulation is paused is fixed. Always zooms out on 2 clicks in the time frame now.
Can click on and visit other planets when zoomed into a body.
Home scene, info scene, and equations scenes implement disabling interactibility with the  buttons once one is clicked.